### PR TITLE
fix: Fix empty item list during list rebuild

### DIFF
--- a/packages/use-item-list/src/index.ts
+++ b/packages/use-item-list/src/index.ts
@@ -85,6 +85,7 @@ export function useItemList({
   const itemListForceUpdate = useForceUpdate()
   const highlightedIndex = useRef<number>(initialHighlightedIndex)
   const items = useRef([])
+  const previousItems = useRef([])
   const shouldCollectItems = useRef(true)
   const invalidatedItems = useRef(false)
   const storeItem = useCallback(({ ref, text, value, disabled }) => {
@@ -115,17 +116,22 @@ export function useItemList({
     return itemIndex
   }, [])
 
-  // clear items on every render before collecting children
+  // clear items on every render before collecting children.
+  // we keep a copy of the previous items in case SELECT_ITEM
+  // is emitted while items are collected.
+  // this way we always have a valid item list.
+  previousItems.current = items.current;
   items.current = []
   shouldCollectItems.current = true
   useIsomorphicEffect(() => {
     shouldCollectItems.current = false
+    previousItems.current = []
   })
 
   // Select
   useEffect(() => {
     function handleSelect(selectedIndex) {
-      const item = items.current[selectedIndex]
+      const item = items.current[selectedIndex] || previousItems.current[selectedIndex]
       if (onSelect && item) {
         onSelect(item, selectedIndex)
       }

--- a/packages/use-item-list/src/index.ts
+++ b/packages/use-item-list/src/index.ts
@@ -85,26 +85,26 @@ export function useItemList({
   const itemListForceUpdate = useForceUpdate()
   const highlightedIndex = useRef<number>(initialHighlightedIndex)
   const items = useRef([])
-  const previousItems = useRef([])
+  const nextItems = useRef([])
   const shouldCollectItems = useRef(true)
   const invalidatedItems = useRef(false)
   const storeItem = useCallback(({ ref, text, value, disabled }) => {
-    let itemIndex = items.current.findIndex(item => item.value === value)
+    let itemIndex = nextItems.current.findIndex(item => item.value === value)
 
     // First, we check if the incoming ref is new and
     // determine if the parent has set shouldCollectRefs or not.
     // If it hasn't, we need to refetch refs by their tree order
     if (
       itemIndex === -1 &&
-      items.current.length > 0 &&
+      nextItems.current.length > 0 &&
       shouldCollectItems.current === false
     ) {
       // stop collecting refs and start over in forced parent render
       // since the collection has been invalidated
       invalidatedItems.current = true
     } else if (itemIndex === -1) {
-      itemIndex = items.current.length
-      items.current.push({
+      itemIndex = nextItems.current.length
+      nextItems.current.push({
         id: getItemId(itemIndex),
         ref,
         text,
@@ -116,22 +116,21 @@ export function useItemList({
     return itemIndex
   }, [])
 
-  // clear items on every render before collecting children.
-  // we keep a copy of the previous items in case SELECT_ITEM
-  // is emitted while items are collected.
-  // this way we always have a valid item list.
-  previousItems.current = items.current;
-  items.current = []
+  // Clear nextItems on every render before collecting items
+  nextItems.current = []
   shouldCollectItems.current = true
+
   useIsomorphicEffect(() => {
+    // This effect runs after all children were stored, so we
+    // can now apply the collected items to the items array
+    items.current = nextItems.current
     shouldCollectItems.current = false
-    previousItems.current = []
   })
 
   // Select
   useEffect(() => {
     function handleSelect(selectedIndex) {
-      const item = items.current[selectedIndex] || previousItems.current[selectedIndex]
+      const item = items.current[selectedIndex]
       if (onSelect && item) {
         onSelect(item, selectedIndex)
       }


### PR DESCRIPTION
Fixes #6 
Fixes #8

When `selectHighlightedItem` or other functions relying on `items.current` are called while the list is being rebuilt (i.e. after it's been cleared and before it's fully repopulated again), it can result in items resolving as undefined, causing runtime errors or preventing the `onSelect` function from being called when it should.

This PR changes the code so that the `items` array is never cleared. Instead, new children are collected to a new `nextItems` variable that's used to replace `items` only once the collection is done. This makes it safe to access `items.current` at all times, even while the item list is being rebuilt.